### PR TITLE
Enhancement: Added new setting "Overwrite Previous Demos"

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -668,6 +668,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "dsda_organize_failed_demos", dsda_config_organize_failed_demos,
     CONF_BOOL(0)
   },
+  [dsda_config_overwrite_previous_demos] = {
+    "dsda_overwrite_previous_demos", dsda_config_overwrite_previous_demos,
+    CONF_BOOL(0)
+  },
   [dsda_config_artifact_descriptions] = {
    "dsda_artifact_descriptions", dsda_config_artifact_descriptions,
     dsda_config_int, 0, 3, { 1 }

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -668,8 +668,8 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "dsda_organize_failed_demos", dsda_config_organize_failed_demos,
     CONF_BOOL(0)
   },
-  [dsda_config_overwrite_previous_demos] = {
-    "dsda_overwrite_previous_demos", dsda_config_overwrite_previous_demos,
+  [dsda_config_only_keep_latest_demo] = {
+    "dsda_only_keep_latest_demo", dsda_config_only_keep_latest_demo,
     CONF_BOOL(0)
   },
   [dsda_config_artifact_descriptions] = {

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -127,6 +127,7 @@ enum {
   dsda_config_mute_unfocused_window,
   dsda_config_cheat_codes,
   dsda_config_organize_failed_demos,
+  dsda_config_overwrite_previous_demos,
   dsda_config_artifact_descriptions,
   dsda_config_hexen_skip_ethereal_travel,
   dsda_config_hexen_simpler_puzzle_use,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -127,7 +127,7 @@ enum {
   dsda_config_mute_unfocused_window,
   dsda_config_cheat_codes,
   dsda_config_organize_failed_demos,
-  dsda_config_overwrite_previous_demos,
+  dsda_config_only_keep_latest_demo,
   dsda_config_artifact_descriptions,
   dsda_config_hexen_skip_ethereal_travel,
   dsda_config_hexen_simpler_puzzle_use,

--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -121,8 +121,10 @@ char* dsda_GenerateDemoName(unsigned int* counter, const char* base_name) {
   demo_name = Z_Malloc(demo_name_size);
   snprintf(demo_name, demo_name_size, "%s.lmp", base_name);
 
-  for (; j <= 99999 && M_FileExists(demo_name); j++)
-    snprintf(demo_name, demo_name_size, "%s-%05d.lmp", base_name, j);
+  if (!dsda_IntConfig(dsda_config_overwrite_previous_demos)) {
+    for (; j <= 99999 && M_FileExists(demo_name); j++)
+      snprintf(demo_name, demo_name_size, "%s-%05d.lmp", base_name, j);
+  }
 
   *counter = j;
 

--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -122,6 +122,8 @@ char* dsda_GenerateDemoName(unsigned int* counter, const char* base_name) {
   snprintf(demo_name, demo_name_size, "%s.lmp", base_name);
 
   if (!dsda_IntConfig(dsda_config_overwrite_previous_demos)) {
+    snprintf(demo_name, demo_name_size, "%s-%05d.lmp", base_name, j); // for the "M_FileExists(demo_name)" check below; will check with the counter already appended 
+
     for (; j <= 99999 && M_FileExists(demo_name); j++)
       snprintf(demo_name, demo_name_size, "%s-%05d.lmp", base_name, j);
   }
@@ -134,8 +136,8 @@ char* dsda_GenerateDemoName(unsigned int* counter, const char* base_name) {
 #define ADD_FILE_COUNTER static unsigned int counter; \
                          DO_ONCE \
                            counter = dsda_DemoAttempts(); \
-                           if (counter < 2) \
-                             counter = 2; \
+                           if (counter < 1) \
+                             counter = 1; \
                          END_ONCE
 
 char* dsda_FallbackDemoName(void) {

--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -128,6 +128,10 @@ char* dsda_GenerateDemoName(unsigned int* counter, const char* base_name) {
       snprintf(demo_name, demo_name_size, "%s-%05d.lmp", base_name, j);
   }
 
+  else {
+    j++;
+  }
+
   *counter = j;
 
   return demo_name;

--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -121,7 +121,7 @@ char* dsda_GenerateDemoName(unsigned int* counter, const char* base_name) {
   demo_name = Z_Malloc(demo_name_size);
   snprintf(demo_name, demo_name_size, "%s.lmp", base_name);
 
-  if (!dsda_IntConfig(dsda_config_overwrite_previous_demos)) {
+  if (!dsda_IntConfig(dsda_config_only_keep_latest_demo)) {
     snprintf(demo_name, demo_name_size, "%s-%05d.lmp", base_name, j); // for the "M_FileExists(demo_name)" check below; will check with the counter already appended 
 
     for (; j <= 99999 && M_FileExists(demo_name); j++)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -34,6 +34,7 @@
  *
  *-----------------------------------------------------------------------------*/
 
+#include "dsda/configuration.h"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -6311,6 +6312,7 @@ setup_menu_t demos_options_settings[] =  // Demos Settings screen
   { "Smooth Playback Factor", S_NUM, m_conf, g_all, DM_X, dsda_config_demo_smoothturnsfactor },
   { "Cycle Ghost Colors", S_YESNO, m_conf, g_all, DM_X, dsda_config_cycle_ghost_colors },
   { "Organize Failed Demos", S_YESNO,  m_conf, g_all, DM_X, dsda_config_organize_failed_demos },
+  { "Overwrite Previous Demos", S_YESNO | S_NYAN, m_conf, g_all, DM_X, dsda_config_overwrite_previous_demos },
 
   NEXT_PAGE(demos_tas_settings),
   FINAL_ENTRY

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -6312,7 +6312,7 @@ setup_menu_t demos_options_settings[] =  // Demos Settings screen
   { "Smooth Playback Factor", S_NUM, m_conf, g_all, DM_X, dsda_config_demo_smoothturnsfactor },
   { "Cycle Ghost Colors", S_YESNO, m_conf, g_all, DM_X, dsda_config_cycle_ghost_colors },
   { "Organize Failed Demos", S_YESNO,  m_conf, g_all, DM_X, dsda_config_organize_failed_demos },
-  { "Overwrite Previous Demos", S_YESNO | S_NYAN, m_conf, g_all, DM_X, dsda_config_overwrite_previous_demos },
+  { "Only Keep Latest Demo", S_YESNO | S_NYAN, m_conf, g_all, DM_X, dsda_config_only_keep_latest_demo },
 
   NEXT_PAGE(demos_tas_settings),
   FINAL_ENTRY

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -456,6 +456,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_doomguy_angry_face_fix),
   MIGRATED_SETTING(dsda_config_blockmap_fix),
   MIGRATED_SETTING(dsda_config_organize_failed_demos),
+  MIGRATED_SETTING(dsda_config_overwrite_previous_demos),
   MIGRATED_SETTING(dsda_config_demo_end_quit),
   MIGRATED_SETTING(dsda_config_artifact_descriptions),
   MIGRATED_SETTING(dsda_config_hexen_skip_ethereal_travel),

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -456,7 +456,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_doomguy_angry_face_fix),
   MIGRATED_SETTING(dsda_config_blockmap_fix),
   MIGRATED_SETTING(dsda_config_organize_failed_demos),
-  MIGRATED_SETTING(dsda_config_overwrite_previous_demos),
+  MIGRATED_SETTING(dsda_config_only_keep_latest_demo),
   MIGRATED_SETTING(dsda_config_demo_end_quit),
   MIGRATED_SETTING(dsda_config_artifact_descriptions),
   MIGRATED_SETTING(dsda_config_hexen_skip_ethereal_travel),


### PR DESCRIPTION
this is a feature that cu2 and me too would love to have. 

<img width="1376" height="720" alt="2026-07-19_17-35-05" src="https://github.com/user-attachments/assets/ec8f8c1a-4fb9-4b21-90f4-c45e3d8fc6cb" />

This has been added as a new option under DEMOS. 
Note that the default setting is still "NO", so by default it will work like it always did.
<img width="1636" height="793" alt="2026-07-19_17-36-54" src="https://github.com/user-attachments/assets/965de63b-ac86-48b2-92c4-a4625bc3f9c4" />


I think that maybe we could change it from "dsda_config_overwrite_previous_demos" to "nyan_config_overwrite_previous_demos" under "SETTING_HEADING("Nyan-Doom settings"),", but since my last PR had "dsda_config_switch_speed" instead of "nyan_config_switch_speed" I decided to keep it under dsda, but I'm not sure if it's the correct choice.

But most important of all, I tested this on my Linux machine and it worked. If someone else has a mac and a windows computer to test this too that would be great, as I'm not sure how other systems would behave with this update