### PR TITLE
Enhancement: Added new menu option "Menu Entry Highlighting"

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -272,6 +272,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "nyan_play_demos_in_menu", nyan_config_menu_play_demo,
     CONF_BOOL(1)
   },
+  [dsda_config_menu_highlight] = {
+    "menu_highlight", dsda_config_menu_highlight,
+    CONF_BOOL(1)
+  },
   [dsda_config_menu_background] = {
     "menu_background", dsda_config_menu_background,
     dsda_config_int, 0, 2, { 1 }

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -29,6 +29,7 @@ enum {
   dsda_config_default_skill,
   dsda_config_vanilla_keymap,
   nyan_config_menu_play_demo,
+  dsda_config_menu_highlight,
   dsda_config_menu_background,
   dsda_config_process_priority,
   dsda_config_max_player_corpse,

--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -501,7 +501,7 @@ void MN_Drawer(void)
     int color = CR_DEFAULT;
 
     // Lighten current item
-    if (i == itemOn)
+    if (i == itemOn && dsda_IntConfig(dsda_config_menu_highlight) == 1)
       color += CR_LIGHTEN;
 
     if (text_sml) {  // use small font for custom skill
@@ -711,7 +711,7 @@ static void MN_DrawFileSlots(int x, int y, int menu)
     int color = CR_DEFAULT;
     int flags = VPT_STRETCH;
 
-    if (M_FileBoxHighlight(menu, i))
+    if (M_FileBoxHighlight(menu, i) && dsda_IntConfig(dsda_config_menu_highlight) == 1)
       color += CR_LIGHTEN;
 
     if (color != CR_DEFAULT)
@@ -944,7 +944,7 @@ void MN_DrawSlider(int x, int y, int width, int range, int slot, dboolean highli
   int color = CR_DEFAULT;
   int flags = VPT_STRETCH;
 
-  if (highlight)
+  if (highlight && dsda_IntConfig(dsda_config_menu_highlight) == 1)
     color += CR_LIGHTEN;
 
   if (color != CR_DEFAULT)

--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -501,7 +501,7 @@ void MN_Drawer(void)
     int color = CR_DEFAULT;
 
     // Lighten current item
-    if (i == itemOn && dsda_IntConfig(dsda_config_menu_highlight) == 1)
+    if (i == itemOn && dsda_IntConfig(dsda_config_menu_highlight))
       color += CR_LIGHTEN;
 
     if (text_sml) {  // use small font for custom skill
@@ -711,7 +711,7 @@ static void MN_DrawFileSlots(int x, int y, int menu)
     int color = CR_DEFAULT;
     int flags = VPT_STRETCH;
 
-    if (M_FileBoxHighlight(menu, i) && dsda_IntConfig(dsda_config_menu_highlight) == 1)
+    if (M_FileBoxHighlight(menu, i) && dsda_IntConfig(dsda_config_menu_highlight))
       color += CR_LIGHTEN;
 
     if (color != CR_DEFAULT)
@@ -944,7 +944,7 @@ void MN_DrawSlider(int x, int y, int width, int range, int slot, dboolean highli
   int color = CR_DEFAULT;
   int flags = VPT_STRETCH;
 
-  if (highlight && dsda_IntConfig(dsda_config_menu_highlight) == 1)
+  if (highlight && dsda_IntConfig(dsda_config_menu_highlight))
     color += CR_LIGHTEN;
 
   if (color != CR_DEFAULT)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -972,6 +972,9 @@ dboolean M_FileBoxHighlight(int menu, int item)
 
 int M_FileTextColor(int menu, int item)
 {
+  if (!dsda_IntConfig(dsda_config_menu_highlight))
+    return CR_DEFAULT;
+
   return M_FileSlotEnabled(menu, item) ? CR_DEFAULT : CR_DARKEN;
 }
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1011,7 +1011,7 @@ static void M_DrawSaveLoadBorder(int x,int y,dboolean highlight)
   int color = CR_DEFAULT;
   int flags = VPT_STRETCH;
 
-  if (highlight)
+  if (highlight && dsda_IntConfig(dsda_config_menu_highlight) == 1)
     color += CR_LIGHTEN;
 
   if (color != CR_DEFAULT)
@@ -5247,6 +5247,7 @@ setup_menu_t display_options_settings[] = {
   { "Palette On Powers", S_CHOICE | S_NYAN, m_conf, g_all, G_X, dsda_config_palette_onpowers, 0, palette_list },
   { "Palette On Effects", S_CHOICE | S_NYAN, m_conf, g_all, G_X, dsda_config_palette_oneffects, 0, palette_reduced_list },
   EMPTY_LINE,
+  { "Menu Entry Highlighting", S_YESNO | S_NYAN, m_conf, g_all, G_X, dsda_config_menu_highlight, 0 },
   { "Menu Background", S_CHOICE, m_conf, g_all, G_X, dsda_config_menu_background, 0, menu_background_list },
 
   NEXT_PAGE(display_nyan_settings),
@@ -9288,7 +9289,7 @@ void M_Drawer (void)
       int color = currentMenu->menuitems[i].color;
       int flags = VPT_STRETCH;
 
-      if (i == itemOn)
+      if (i == itemOn && dsda_IntConfig(dsda_config_menu_highlight) == 1)
         color += CR_LIGHTEN;
 
       if (color != CR_DEFAULT)
@@ -9428,7 +9429,7 @@ static void M_DrawThermo(int x, int y, int thermWidth, int thermRange, int therm
 
   if (raven) RETURN(MN_DrawSlider(x, y, thermWidth, thermRange, thermDot, highlight));
 
-  if (highlight)
+  if (highlight && dsda_IntConfig(dsda_config_menu_highlight) == 1)
     color += CR_LIGHTEN;
 
   if (color != CR_DEFAULT)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1011,7 +1011,7 @@ static void M_DrawSaveLoadBorder(int x,int y,dboolean highlight)
   int color = CR_DEFAULT;
   int flags = VPT_STRETCH;
 
-  if (highlight && dsda_IntConfig(dsda_config_menu_highlight) == 1)
+  if (highlight && dsda_IntConfig(dsda_config_menu_highlight))
     color += CR_LIGHTEN;
 
   if (color != CR_DEFAULT)
@@ -9289,7 +9289,7 @@ void M_Drawer (void)
       int color = currentMenu->menuitems[i].color;
       int flags = VPT_STRETCH;
 
-      if (i == itemOn && dsda_IntConfig(dsda_config_menu_highlight) == 1)
+      if (i == itemOn && dsda_IntConfig(dsda_config_menu_highlight))
         color += CR_LIGHTEN;
 
       if (color != CR_DEFAULT)
@@ -9429,7 +9429,7 @@ static void M_DrawThermo(int x, int y, int thermWidth, int thermRange, int therm
 
   if (raven) RETURN(MN_DrawSlider(x, y, thermWidth, thermRange, thermDot, highlight));
 
-  if (highlight && dsda_IntConfig(dsda_config_menu_highlight) == 1)
+  if (highlight && dsda_IntConfig(dsda_config_menu_highlight))
     color += CR_LIGHTEN;
 
   if (color != CR_DEFAULT)

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -84,6 +84,7 @@ cfg_def_t cfg_defs[] =
 
   SETTING_HEADING("Misc settings"),
   MIGRATED_SETTING(dsda_config_vanilla_keymap),
+  MIGRATED_SETTING(dsda_config_menu_highlight),
   MIGRATED_SETTING(dsda_config_menu_background),
   MIGRATED_SETTING(dsda_config_max_player_corpse),
   MIGRATED_SETTING(dsda_config_flashing_hom),


### PR DESCRIPTION

<img width="1770" height="968" alt="2026-07-22_20-32-07" src="https://github.com/user-attachments/assets/a47440a6-e1ac-41f7-9bbb-af14537520ef" />

Implemented a new option to disable the highlighting effects requested by the user Dinoaur. Tested and working in DOOM, DOOM2, Heretic and Hexen. Menu entries, menu thermos, save/load files all working.

<img width="1082" height="1037" alt="2026-07-22_20-34-19" src="https://github.com/user-attachments/assets/45de66f2-f367-4b67-ab16-7f0596a8ac81" />


Placed it in the "DISPLAY" Section, above "Menu Background". I decided to put it above because in my mind it made a bit more sense, but tell me if we should move it away from "DISPLAY" entirely or change its position.

Also, tell me if the way I implemented it should be revised, because it may or may not be future-proof with mouse compatibility depending on how you implement it.


Menu Entry Highlighting - YES:
<img width="1821" height="967" alt="2026-07-22_20-58-27" src="https://github.com/user-attachments/assets/8dd956b8-5d12-4465-b136-c427e09b89c7" />


Menu Entry Highlighting - NO:
<img width="1882" height="1022" alt="2026-07-22_20-58-18" src="https://github.com/user-attachments/assets/8e409c11-0dc4-4ce4-bcff-ab38d29ffd19" />
