### PR TITLE
Do pre-tic interpolation for all mobjs

### DIFF
--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -1996,7 +1996,11 @@ dboolean P_ThingHeightClip (mobj_t* thing)
       (thing->z - thing->floorz < 9 * FRACUNIT) ||
       (thing->flags & MF_NOGRAVITY)
     )
+    {
+      thing->PrevZ = thing->z;
       thing->z = thing->floorz;
+      thing->intflags |= MIF_NOINTERPOLATEZ;
+    }
 
     /* killough 11/98: Possibly upset balance of objects hanging off ledges */
     if (thing->intflags & MIF_FALLING && thing->gear >= MAXGEAR)
@@ -2007,7 +2011,11 @@ dboolean P_ThingHeightClip (mobj_t* thing)
     // don't adjust a floating monster unless forced to
 
     if (thing->z+thing->height > thing->ceilingz)
+    {
+      thing->PrevZ = thing->z;
       thing->z = thing->ceilingz - thing->height;
+      thing->intflags |= MIF_NOINTERPOLATEZ;
+    }
   }
 
   return thing->ceilingz - thing->floorz >= thing->height;

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1316,7 +1316,9 @@ void P_MobjThinker (mobj_t* mobj)
 
   mobj->PrevX = mobj->x;
   mobj->PrevY = mobj->y;
-  mobj->PrevZ = mobj->z;
+  if (!(mobj->intflags & MIF_NOINTERPOLATEZ))
+    mobj->PrevZ = mobj->z;
+  mobj->intflags &= ~MIF_NOINTERPOLATEZ;
 
   // momentum movement
   BlockingMobj = NULL;
@@ -3197,7 +3199,9 @@ void P_BlasterMobjThinker(mobj_t * mobj)
 
     mobj->PrevX = mobj->x;
     mobj->PrevY = mobj->y;
-    mobj->PrevZ = mobj->z;
+    if (!(mobj->intflags & MIF_NOINTERPOLATEZ))
+        mobj->PrevZ = mobj->z;
+    mobj->intflags &= ~MIF_NOINTERPOLATEZ;
 
     // Handle movement
     if (mobj->momx || mobj->momy || (mobj->z != mobj->floorz) || mobj->momz)

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -248,6 +248,7 @@ enum {
   MIF_SPAWNED_BY_DSPARIL    = (1<<5),
   MIF_FLIP                  = (1<<6),
   MIF_FAKE                  = (1<<7), // Not a real thing, transient (e.g., for cheats)
+  MIF_NOINTERPOLATEZ        = (1<<8), // [AR] Prevent mobj thinker from overwriting an updated PrevZ (example: lift thinker)
 };
 
 // heretic


### PR DESCRIPTION
So I've noticed a flaw with mobj interpolation...

Basically, usually when interpolation is added at the start of a map, the item thinkers are processed before the lift thinkers....

This means that when they go up and down on lifts, interpolation works correctly.

However there is a flaw, in that if an enemy drops an item, that item ends up getting processed after the lift thinker... resulting in z "jittering" as it uses the wrong interpolation value.

By calculating interpolation for all mobjs before it reaches the thinkers, we fix the jitter problem and ensure their previous z positions are always recorded before the lift thinkers can move them.

The slight downside is that we are forced to use the thinker list processing for every mobj, whereas before we did it manually inside the mobj itself. I'm not sure how much this would affect things, but UZDoom seems to do this right now.

Worth noting that Eternity and Woof have this problem when it comes to items dropped on lifts.