### PR TITLE
Do pre-tic interpolation for all mobjs (Take II)

### DIFF
--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -1973,6 +1973,8 @@ dboolean P_ThingHeightClip (mobj_t* thing)
 {
   dboolean   onfloor;
 
+  P_MobjInterpolation(thing);
+
   onfloor = (thing->z == thing->floorz);
 
   P_CheckPosition (thing, thing->x, thing->y);

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1289,6 +1289,33 @@ static dboolean P_KillOnSight(mobj_t *mo)
 }
 
 //
+// P_MobjInterpolation
+//
+
+static dboolean mobj_interp_capture;
+
+void P_UpdateMobjInterpolations(void)
+{
+  mobj_interp_capture = !mobj_interp_capture;
+}
+
+// [AR] Save mobj interpolation once per tic
+// This fixes out-of-sync thinker order of operations (i.e. lift thinkers)
+void P_MobjInterpolation(mobj_t *mobj)
+{
+  dboolean captured = !!(mobj->intflags & MIF_INTERP_CAPTURE);
+
+  if (captured == mobj_interp_capture)
+    return;
+
+  mobj->PrevX = mobj->x;
+  mobj->PrevY = mobj->y;
+  mobj->PrevZ = mobj->z;
+
+  mobj->intflags ^= MIF_INTERP_CAPTURE;
+}
+
+//
 // P_MobjThinker
 //
 
@@ -1314,9 +1341,7 @@ void P_MobjThinker (mobj_t* mobj)
     return;
   }
 
-  mobj->PrevX = mobj->x;
-  mobj->PrevY = mobj->y;
-  mobj->PrevZ = mobj->z;
+  P_MobjInterpolation(mobj);
 
   // momentum movement
   BlockingMobj = NULL;
@@ -2000,6 +2025,9 @@ mobj_t* P_SpawnMobj(fixed_t x,fixed_t y,fixed_t z,mobjtype_t type)
   mobj->PrevX = mobj->x;
   mobj->PrevY = mobj->y;
   mobj->PrevZ = mobj->z;
+
+  if (mobj_interp_capture)
+    mobj->intflags |= MIF_INTERP_CAPTURE;
 
   mobj->thinker.function = P_MobjThinker;
 
@@ -3195,9 +3223,7 @@ void P_BlasterMobjThinker(mobj_t * mobj)
     fixed_t z;
     dboolean changexy;
 
-    mobj->PrevX = mobj->x;
-    mobj->PrevY = mobj->y;
-    mobj->PrevZ = mobj->z;
+    P_MobjInterpolation(mobj);
 
     // Handle movement
     if (mobj->momx || mobj->momy || (mobj->z != mobj->floorz) || mobj->momz)

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -248,6 +248,7 @@ enum {
   MIF_SPAWNED_BY_DSPARIL    = (1<<5),
   MIF_FLIP                  = (1<<6),
   MIF_FAKE                  = (1<<7), // Not a real thing, transient (e.g., for cheats)
+  MIF_INTERP_CAPTURE        = (1<<8), // [AR] Capture interpolation once per tic
 };
 
 // heretic
@@ -455,6 +456,8 @@ mobj_t  *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type);
 void    P_RemoveMobj(mobj_t *th);
 dboolean P_SetMobjState(mobj_t *mobj, statenum_t state);
 void    P_MobjThinker(mobj_t *mobj);
+void    P_UpdateMobjInterpolations(void);
+void    P_MobjInterpolation(mobj_t *mobj);
 void    P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z);
 void    P_SpawnBlood(fixed_t x, fixed_t y, fixed_t z, int damage, mobj_t *bleeder);
 mobj_t  *P_SpawnMissile(mobj_t *source, mobj_t *dest, mobjtype_t type);

--- a/prboom2/src/r_fps.c
+++ b/prboom2/src/r_fps.c
@@ -414,6 +414,9 @@ static void R_DoAnInterpolation (int i, fixed_t smoothratio)
 void R_UpdateInterpolations()
 {
   int i;
+
+  P_UpdateMobjInterpolations();
+
   if (!movement_smooth)
     return;
   for (i = numinterpolations-1; i >= 0; --i)


### PR DESCRIPTION
The last method (https://github.com/andrikpowell/nyan-doom/pull/52) fixed things on lifts, but added extra jitter to everything else.

This approach is probably better, fixes that issue and avoids checking the thinkerlist every tic.